### PR TITLE
disable functionality in instances

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.npcidletimer'
-version = '1.2'
+version = '1.2.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/npcidletimer/NPCIdleTimerOverlay.java
+++ b/src/main/java/com/npcidletimer/NPCIdleTimerOverlay.java
@@ -6,6 +6,7 @@ import java.awt.Graphics2D;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import javax.inject.Inject;
+import net.runelite.api.Client;
 import net.runelite.api.Point;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -15,6 +16,7 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 public class NPCIdleTimerOverlay extends Overlay
 {
 
+	private final Client client;
 	private final NPCIdleTimerPlugin plugin;
 	private final NPCIdleTimerConfig config;
 
@@ -23,10 +25,11 @@ public class NPCIdleTimerOverlay extends Overlay
 	int NPC_IDLE_RESPAWN_TIME = 300;
 
 	@Inject
-	NPCIdleTimerOverlay(NPCIdleTimerPlugin plugin, NPCIdleTimerConfig config)
+	NPCIdleTimerOverlay(Client client, NPCIdleTimerPlugin plugin, NPCIdleTimerConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
+		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
 	}
@@ -34,6 +37,11 @@ public class NPCIdleTimerOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		if (client.isInInstancedRegion())
+		{
+			return null;
+		}
+
 		if (config.showOverlay())
 		{
 			plugin.getWanderingNPCs().forEach((id, npc) -> renderTimer(npc, graphics));

--- a/src/main/java/com/npcidletimer/NPCIdleTimerPlugin.java
+++ b/src/main/java/com/npcidletimer/NPCIdleTimerPlugin.java
@@ -80,6 +80,11 @@ public class NPCIdleTimerPlugin extends Plugin
 	@Subscribe
 	public void onNpcSpawned(NpcSpawned npcSpawned)
 	{
+		if (client.isInInstancedRegion())
+		{
+			return;
+		}
+
 		final NPC npc = npcSpawned.getNpc();
 		final String npcName = npc.getName();
 
@@ -94,6 +99,11 @@ public class NPCIdleTimerPlugin extends Plugin
 	@Subscribe
 	public void onNpcDespawned(NpcDespawned npcDespawned)
 	{
+		if (client.isInInstancedRegion())
+		{
+			return;
+		}
+
 		final NPC npc = npcDespawned.getNpc();
 		final String npcName = npc.getName();
 
@@ -118,6 +128,11 @@ public class NPCIdleTimerPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
+		if (client.isInInstancedRegion())
+		{
+			return;
+		}
+
 		lastTrueTickUpdate = client.getTickCount();
 		lastTickUpdate = Instant.now();
 


### PR DESCRIPTION
Currently the plugin is capable of rendering a custom idle timer over Bloat at the Theatre of Blood, indicating when it will awake. This is against the [Third Party Client Guidelines](https://secure.runescape.com/m=news/third-party-client-guidelines?oldschool=1).

In order to mitigate this, the PR disables tracking and overlay of NPCs while in instanced regions altogether.

Failure to merge and submit this fix to the plugin hub may result in your plugin being disabled.