### PR TITLE
Fixes for custom timer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.24.3'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.npcidletimer'
-version = '1.2'
+version = '1.3'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/npcidletimer/NPCIdleTimerConfig.java
+++ b/src/main/java/com/npcidletimer/NPCIdleTimerConfig.java
@@ -57,7 +57,7 @@ public interface NPCIdleTimerConfig extends Config
 	}
 
 	@Range(
-			max = 300
+			max = 999
 	)
 	@ConfigItem(
 			position = 4,
@@ -70,9 +70,6 @@ public interface NPCIdleTimerConfig extends Config
 		return 300;
 	}
 
-	@Range(
-			max = 300
-	)
 	@ConfigItem(
 			position = 5,
 			keyName = "customTimer",
@@ -83,6 +80,10 @@ public interface NPCIdleTimerConfig extends Config
 	{
 		return false;
 	}
+
+	@Range(
+			max = 999
+	)
 	@ConfigItem(
 			position = 6,
 			keyName = "customTiming",
@@ -95,7 +96,7 @@ public interface NPCIdleTimerConfig extends Config
 	}
 
 	@Range(
-			max = 300
+			max = 999
 	)
 	@ConfigItem(
 			position = 7,

--- a/src/main/java/com/npcidletimer/NPCIdleTimerConfig.java
+++ b/src/main/java/com/npcidletimer/NPCIdleTimerConfig.java
@@ -57,7 +57,7 @@ public interface NPCIdleTimerConfig extends Config
 	}
 
 	@Range(
-			max = 999
+			max = 300
 	)
 	@ConfigItem(
 			position = 4,

--- a/src/main/java/com/npcidletimer/NPCIdleTimerConfig.java
+++ b/src/main/java/com/npcidletimer/NPCIdleTimerConfig.java
@@ -92,9 +92,6 @@ public interface NPCIdleTimerConfig extends Config
 		return 300;
 	}
 
-	@Range(
-			max = 999
-	)
 	@ConfigItem(
 			position = 7,
 			keyName = "lowDisplay",

--- a/src/main/java/com/npcidletimer/NPCIdleTimerConfig.java
+++ b/src/main/java/com/npcidletimer/NPCIdleTimerConfig.java
@@ -81,9 +81,6 @@ public interface NPCIdleTimerConfig extends Config
 		return false;
 	}
 
-	@Range(
-			max = 999
-	)
 	@ConfigItem(
 			position = 6,
 			keyName = "customTiming",

--- a/src/main/java/com/npcidletimer/NPCIdleTimerOverlay.java
+++ b/src/main/java/com/npcidletimer/NPCIdleTimerOverlay.java
@@ -20,8 +20,6 @@ public class NPCIdleTimerOverlay extends Overlay
 
 	NumberFormat format = new DecimalFormat("#");
 
-	int NPC_IDLE_RESPAWN_TIME = 300;
-
 	@Inject
 	NPCIdleTimerOverlay(NPCIdleTimerPlugin plugin, NPCIdleTimerConfig config)
 	{
@@ -43,19 +41,18 @@ public class NPCIdleTimerOverlay extends Overlay
 
 	private void renderTimer(final WanderingNPC npc, final Graphics2D graphics)
 	{
-		if ( config.customTimer())
+		int npc_idle_respawn_time = 300;
+		double maxDisplay = config.maxDisplay();
+
+		if (config.customTimer())
 		{
-			NPC_IDLE_RESPAWN_TIME = config.customTiming();
-		}
-		else
-		{
-			NPC_IDLE_RESPAWN_TIME = 300;
+			npc_idle_respawn_time = config.customTiming();
+			maxDisplay = config.customTimer();
 		}
 
-		double timeLeft = NPC_IDLE_RESPAWN_TIME - npc.getTimeWithoutMoving();
+		double timeLeft = npc_idle_respawn_time - npc.getTimeWithoutMoving();
 
 		double lowDisplay = config.lowDisplay();
-		double maxDisplay = config.maxDisplay();
 		Color timerColor = config.normalTimerColor();
 
 		if (timeLeft < 0)
@@ -68,15 +65,14 @@ public class NPCIdleTimerOverlay extends Overlay
 			timerColor = config.lowTimerColor();
 		}
 
-		String timeLeftString= String.valueOf(format.format(timeLeft));
+		String timeLeftString = String.valueOf(format.format(timeLeft));
 
-		if(config.showTimingType())
+		if (config.showTimingType())
 		{
 			if (config.showOverlayTicks())
 			{
 				timeLeftString = timeLeftString + ("T");
 			}
-
 			else
 			{
 				timeLeftString= timeLeftString + ("S");

--- a/src/main/java/com/npcidletimer/NPCIdleTimerOverlay.java
+++ b/src/main/java/com/npcidletimer/NPCIdleTimerOverlay.java
@@ -41,16 +41,14 @@ public class NPCIdleTimerOverlay extends Overlay
 
 	private void renderTimer(final WanderingNPC npc, final Graphics2D graphics)
 	{
-		int npc_idle_respawn_time = 300;
 		double maxDisplay = config.maxDisplay();
 
 		if (config.customTimer())
 		{
-			npc_idle_respawn_time = config.customTiming();
 			maxDisplay = config.customTiming();
 		}
 
-		double timeLeft = npc_idle_respawn_time - npc.getTimeWithoutMoving();
+		double timeLeft = maxDisplay - npc.getTimeWithoutMoving();
 
 		double lowDisplay = config.lowDisplay();
 		Color timerColor = config.normalTimerColor();

--- a/src/main/java/com/npcidletimer/NPCIdleTimerOverlay.java
+++ b/src/main/java/com/npcidletimer/NPCIdleTimerOverlay.java
@@ -47,7 +47,7 @@ public class NPCIdleTimerOverlay extends Overlay
 		if (config.customTimer())
 		{
 			npc_idle_respawn_time = config.customTiming();
-			maxDisplay = config.customTimer();
+			maxDisplay = config.customTiming();
 		}
 
 		double timeLeft = npc_idle_respawn_time - npc.getTimeWithoutMoving();


### PR DESCRIPTION
This should fix the issues in https://github.com/vonpawn/npc-idle-timer-plugin/issues/4

- Removed a Range from a boolean param since I'm assuming that won't do anything
- Remove the Range from the `lowDisplay` since it applies to both the default and custom timer
- If the custom timer is enabled, set the max value of the timer to that value instead of always using the max value of the default timer. This will prevent the issue of the timer not rendering if the timer value is higher than the max of the default timer.
- Removed the `NPC_IDLE_RESPAWN_TIME` var since it seems like it duplicates the purpose of `config.maxDisplay` or `config.customTiming`
- Cleaned up some whitespace

Tested with a local build and it works!