### PR TITLE
Fix crash when enabling plugin by running NPC rebuild on client thread

### DIFF
--- a/src/main/java/com/npcidletimer/NPCIdleTimerPlugin.java
+++ b/src/main/java/com/npcidletimer/NPCIdleTimerPlugin.java
@@ -26,6 +26,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.Text;
+import net.runelite.client.callback.ClientThread;
 
 @Slf4j
 @PluginDescriptor(
@@ -35,6 +36,9 @@ public class NPCIdleTimerPlugin extends Plugin
 {
 	@Inject
 	private Client client;
+
+	@Inject
+	private ClientThread clientThread;
 
 	@Inject
 	private NPCIdleTimerConfig config;
@@ -67,7 +71,7 @@ public class NPCIdleTimerPlugin extends Plugin
 	{
 		overlayManager.add(npcidletimeroverlay);
 		selectedNPCs = getSelectedNPCs();
-		rebuildAllNpcs();
+		clientThread.invokeLater(this::rebuildAllNpcs);
 	}
 
 	@Override
@@ -192,7 +196,7 @@ public class NPCIdleTimerPlugin extends Plugin
 		}
 
 		selectedNPCs = getSelectedNPCs();
-		rebuildAllNpcs();
+		clientThread.invokeLater(this::rebuildAllNpcs);
 	}
 
 	@VisibleForTesting


### PR DESCRIPTION
Fixes a crash when enabling the plugin: 
"java.lang.IllegalStateException: must be called on client thread" thrown when rebuildAllNpcs is called.

Inject ClientThread and wrap rebuildAllNpcs() calls in clientThread.invokeLater(...)
